### PR TITLE
OPENJDK-2408: binary build with custom s2i assemble script

### DIFF
--- a/OPENJDK-2408-bin-custom-s2i-assemble/.s2i/bin/assemble
+++ b/OPENJDK-2408-bin-custom-s2i-assemble/.s2i/bin/assemble
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -euo pipefail
+
+# we put a sleep here to ensure that there's at least a one second difference
+# between the ctime of the app source (copied in by s2i) and any artefacts
+# created by the build/assemble.
+echo appsrc-provided s2i assemble script executed
+sleep 1
+echo delegating to builder image s2i assemble
+
+exec /usr/local/s2i/assemble "$@"


### PR DESCRIPTION
A variant of spring-boot-sample-simple/target, i.e. a pre-built JAR to provoke the s2i assemble script's "binary" path, with an added .s2i/bin/assemble script which is invoked by s2i instead of the builder image's assemble script.

This script simply ensures there's a minimum of a one second interval between the start of the s2i process (after the application source has been copied into the s2i container) and the invocation of the builder image's assemble script.

This ensures that, if the builder image script does not preserve the modified timestamp of the binary, the time delta is at least one second.