### PR TITLE
[OPENJDK-3597] Test to ensure MAVEN_SETTINGS_XML is functioning

### DIFF
--- a/OPENJDK-3597-custom-settings-xml/README.md
+++ b/OPENJDK-3597-custom-settings-xml/README.md
@@ -1,0 +1,6 @@
+# Test for OPENJDK-3597
+
+<https://issues.redhat.com/browse/OPENJDK-3597>
+
+This is a minimal Maven project which depends upon a particular profile
+being activated (via the enforcer plugin).

--- a/OPENJDK-3597-custom-settings-xml/pom.xml
+++ b/OPENJDK-3597-custom-settings-xml/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.acme</groupId>
+  <artifactId>getting-started</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.3.0</version>
+        <executions>
+
+          <execution>
+            <id>enforce-given-profile-activated</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireActiveProfile>
+                  <profiles>testCustomProfile</profiles>
+                </requireActiveProfile>
+              </rules>
+              <fail>true</fail>
+            </configuration>
+          </execution>
+
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/OPENJDK-3597-custom-settings-xml/settings.xml
+++ b/OPENJDK-3597-custom-settings-xml/settings.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<settings xmlns="http://maven.apache.org/SETTINGS/1.2.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.2.0 https://maven.apache.org/xsd/settings-1.2.0.xsd">
+  <profiles>
+    <profile>
+      <id>testCustomProfile</id>
+    </profile>
+  </profiles>
+
+  <activeProfiles>
+    <activeProfile>testCustomProfile</activeProfile>
+  </activeProfiles>
+</settings>


### PR DESCRIPTION
A custom application source which uses the maven enforcer plugin to ensure the profile "testCustomProfile" is activated.

A custom settings.xml that defines and activates the profile "testCustomProfile"

An S2I build using e.g.
    MAVEN_SETTINGS_XML=/tmp/src/settings.xml \
    MAVEN_ARGS=validate

should pass; settings just MAVEN_ARGS=validate should fail.