### PR TITLE
Adjust path for S2I to permit scripts in /usr/libexec and /usr/local

### DIFF
--- a/OPENJDK-2408-bin-custom-s2i-assemble/.s2i/bin/assemble
+++ b/OPENJDK-2408-bin-custom-s2i-assemble/.s2i/bin/assemble
@@ -8,4 +8,8 @@ echo appsrc-provided s2i assemble script executed
 sleep 1
 echo delegating to builder image s2i assemble
 
-exec /usr/local/s2i/assemble "$@"
+# Adjusting the path ensures that this can find assemble for images which
+# put the s2i scripts at /usr/local/s2i (UBI8, UBI9) as well as those at
+# /usr/libexec/s2i (UBI10).
+PATH=/usr/libexec/s2i:/usr/local/s2i:$PATH
+exec assemble "$@"


### PR DESCRIPTION
UBI8 & 9 images have their s2i scripts in /usr/local/s2i. UBI10 images install scripts to /usr/libexec/s2i.

Adjust the call to "assemble" so it can succeed in both cases.